### PR TITLE
fixed tests by using HttpIntegrationTest integration instead

### DIFF
--- a/http-filter-example/BUILD
+++ b/http-filter-example/BUILD
@@ -43,6 +43,6 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         ":http_filter_config",
-        "@envoy//test/integration:integration_lib",
+        "@envoy//test/integration:http_integration_lib"
     ],
 )

--- a/http-filter-example/envoy.conf
+++ b/http-filter-example/envoy.conf
@@ -26,7 +26,7 @@
             },
             "access_log": [
               {
-                "path": "/dev/stdout"
+                "path": "/dev/null"
               }
             ],
             "filters": [
@@ -47,7 +47,7 @@
     }
   ],
   "admin": {
-    "access_log_path": "/dev/stdout",
+    "access_log_path": "/dev/null",
     "address": "tcp://{{ ip_loopback_address }}:0"
   },
   "cluster_manager": {

--- a/http-filter-example/http_filter_integration_test.cc
+++ b/http-filter-example/http_filter_integration_test.cc
@@ -1,11 +1,11 @@
-#include "test/integration/integration.h"
+#include "test/integration/http_integration.h"
 #include "test/integration/utility.h"
 
 namespace Envoy {
-class HttpFilterSampleIntegrationTest : public BaseIntegrationTest,
+class HttpFilterSampleIntegrationTest : public HttpIntegrationTest,
                                         public testing::TestWithParam<Network::Address::IpVersion> {
 public:
-  HttpFilterSampleIntegrationTest() : BaseIntegrationTest(GetParam()) {}
+  HttpFilterSampleIntegrationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()) {}
   /**
    * Initializer for an individual integration test.
    */
@@ -35,10 +35,10 @@ TEST_P(HttpFilterSampleIntegrationTest, Test1) {
   IntegrationStreamDecoderPtr response(new IntegrationStreamDecoder(*dispatcher_));
   FakeStreamPtr request_stream;
 
-  codec_client = makeHttpConnection(lookupPort("http"), Http::CodecClient::Type::HTTP1);
+  codec_client = makeHttpConnection(lookupPort("http"));
   codec_client->makeHeaderOnlyRequest(headers, *response);
   fake_upstream_connection = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
-  request_stream = fake_upstream_connection->waitForNewStream();
+  request_stream = fake_upstream_connection->waitForNewStream(*dispatcher_);
   request_stream->waitForEndStream(*dispatcher_);
   response->waitForEndStream();
 


### PR DESCRIPTION
I fixed the tests in the http filter example by extending HttpIntegrationTest instead, I had issues with the envoy config writing to `/dev/stdout` so i had to send it to `/dev/null` on OSX

This was the error 
http-filter-example/envoy.conf.with.ports.json': unable to open file '/dev/stdout': Permission denied