### PR TITLE
Porting the echo2 integration test to the v2 API.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -45,7 +45,7 @@ envoy_cc_library(
 envoy_cc_test(
     name = "echo2_integration_test",
     srcs = ["echo2_integration_test.cc"],
-    data =  ["echo2_server.json"],
+    data =  ["echo2_server.yaml"],
     repository = "@envoy",
     deps = [
         ":echo2_config",

--- a/echo2_integration_test.cc
+++ b/echo2_integration_test.cc
@@ -4,13 +4,37 @@
 namespace Envoy {
 class Echo2IntegrationTest : public BaseIntegrationTest,
                              public testing::TestWithParam<Network::Address::IpVersion> {
+
+// TODO(alyssawilk): make this a general util.
+std::string readFileToStringForTest(const std::string& filename) {
+  std::ifstream file(filename);
+  if (file.fail()) {
+    std::cerr << "failed to open: " << filename << std::endl;
+    RELEASE_ASSERT(false);
+  }
+
+  std::stringstream file_string_stream;
+  file_string_stream << file.rdbuf();
+  return file_string_stream.str();
+}
+
+std::string echoConfig() {
+  return readFileToStringForTest(TestEnvironment::runfilesPath("echo2_server.yaml");
+}
+
 public:
-  Echo2IntegrationTest() : BaseIntegrationTest(GetParam()) {}
+  Echo2IntegrationTest() : BaseIntegrationTest(GetParam(), echoConfig()) {}
+
+  // Called once by the gtest framework before any EchoIntegrationTests are run.
+  static void SetUpTestCase() {
+  }
+
   /**
    * Initializer for an individual integration test.
    */
   void SetUp() override {
-    createTestServer("echo2_server.json", {"echo"});
+    named_ports_ = {{"echo"}};
+    BaseIntegrationTest::initialize();
   }
 
   /**
@@ -18,6 +42,7 @@ public:
    */
   void TearDown() override {
     test_server_.reset();
+    fake_upstreams_.clear();
   }
 };
 

--- a/echo2_integration_test.cc
+++ b/echo2_integration_test.cc
@@ -5,30 +5,13 @@ namespace Envoy {
 class Echo2IntegrationTest : public BaseIntegrationTest,
                              public testing::TestWithParam<Network::Address::IpVersion> {
 
-// TODO(alyssawilk): make this a general util.
-std::string readFileToStringForTest(const std::string& filename) {
-  std::ifstream file(filename);
-  if (file.fail()) {
-    std::cerr << "failed to open: " << filename << std::endl;
-    RELEASE_ASSERT(false);
-  }
-
-  std::stringstream file_string_stream;
-  file_string_stream << file.rdbuf();
-  return file_string_stream.str();
-}
-
 std::string echoConfig() {
-  return readFileToStringForTest(TestEnvironment::runfilesPath("echo2_server.yaml");
+  return TestEnvironment::readFileToStringForTest(TestEnvironment::runfilesPath(
+      "echo2_server.yaml"));
 }
 
 public:
   Echo2IntegrationTest() : BaseIntegrationTest(GetParam(), echoConfig()) {}
-
-  // Called once by the gtest framework before any EchoIntegrationTests are run.
-  static void SetUpTestCase() {
-  }
-
   /**
    * Initializer for an individual integration test.
    */

--- a/echo2_server.yaml
+++ b/echo2_server.yaml
@@ -1,0 +1,29 @@
+admin:
+  access_log_path: /dev/null
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 0
+static_resources:
+  clusters:
+    name: cluster_0
+    hosts:
+      socket_address:
+        address: 127.0.0.1
+        port_value: 0
+  listeners:
+    name: listener_0
+    address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: 0
+    filter_chains:
+      filters:
+        name: envoy.ratelimit
+        config:
+          domain: foo
+          stats_prefix: name
+          descriptors: [{"key": "foo", "value": "bar"}]
+      filters:
+        name: envoy.echo
+        config:


### PR DESCRIPTION
Bumping Envoy to 7aa956f1eb17454240646e55e13caf72db850af2
Porting the echo2 integration test to the v2 API.
Leaving the v1 json file in situ (unused) for legacy reference.
