### PR TITLE
Add a proto config example for http-filter-example

### DIFF
--- a/http-filter-example/BUILD
+++ b/http-filter-example/BUILD
@@ -7,6 +7,8 @@ load(
     "envoy_cc_test",
 )
 
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library")
+
 envoy_cc_binary(
     name = "envoy",
     repository = "@envoy",
@@ -16,12 +18,18 @@ envoy_cc_binary(
     ],
 )
 
+api_proto_library(
+    name = "http_filter_proto",
+    srcs = ["http_filter.proto"]
+)
+
 envoy_cc_library(
     name = "http_filter_lib",
     srcs = ["http_filter.cc"],
     hdrs = ["http_filter.h"],
     repository = "@envoy",
     deps = [
+        ":http_filter_proto_cc",
         "@envoy//source/exe:envoy_common_lib",
     ],
 )

--- a/http-filter-example/http_filter.cc
+++ b/http-filter-example/http_filter.cc
@@ -18,19 +18,17 @@ HttpSampleDecoderFilter::~HttpSampleDecoderFilter() {}
 
 void HttpSampleDecoderFilter::onDestroy() {}
 
-const LowerCaseString& HttpSampleDecoderFilter::headerKey() {
-  static LowerCaseString* key = new LowerCaseString(config_->key());
-  return *key;
+const LowerCaseString HttpSampleDecoderFilter::headerKey() const {
+  return LowerCaseString(config_->key());
 }
 
-const std::string& HttpSampleDecoderFilter::headerValue() {
-  static std::string* val = new std::string(config_->val());
-  return *val;
+const std::string HttpSampleDecoderFilter::headerValue() const {
+  return config_->val();
 }
 
 FilterHeadersStatus HttpSampleDecoderFilter::decodeHeaders(HeaderMap& headers, bool) {
   // add a header
-  headers.addReference(headerKey(), headerValue());
+  headers.addCopy(headerKey(), headerValue());
 
   return FilterHeadersStatus::Continue;
 }

--- a/http-filter-example/http_filter.cc
+++ b/http-filter-example/http_filter.cc
@@ -7,19 +7,24 @@
 namespace Envoy {
 namespace Http {
 
-HttpSampleDecoderFilter::HttpSampleDecoderFilter() {}
+HttpSampleDecoderFilterConfig::HttpSampleDecoderFilterConfig(
+    const sample::Decoder& proto_config)
+    : key_(proto_config.key()), val_(proto_config.val()) {}
+
+HttpSampleDecoderFilter::HttpSampleDecoderFilter(HttpSampleDecoderFilterConfigSharedPtr config)
+    : config_(config) {}
 
 HttpSampleDecoderFilter::~HttpSampleDecoderFilter() {}
 
 void HttpSampleDecoderFilter::onDestroy() {}
 
 const LowerCaseString& HttpSampleDecoderFilter::headerKey() {
-  static LowerCaseString* key = new LowerCaseString("via");
+  static LowerCaseString* key = new LowerCaseString(config_->key());
   return *key;
 }
 
 const std::string& HttpSampleDecoderFilter::headerValue() {
-  static std::string* val = new std::string("sample-filter");
+  static std::string* val = new std::string(config_->val());
   return *val;
 }
 
@@ -42,5 +47,5 @@ void HttpSampleDecoderFilter::setDecoderFilterCallbacks(StreamDecoderFilterCallb
   decoder_callbacks_ = &callbacks;
 }
 
-} // Http
-} // Envoy
+} // namespace Http
+} // namespace Envoy

--- a/http-filter-example/http_filter.h
+++ b/http-filter-example/http_filter.h
@@ -41,8 +41,8 @@ private:
   const HttpSampleDecoderFilterConfigSharedPtr config_;
   StreamDecoderFilterCallbacks* decoder_callbacks_;
 
-  const LowerCaseString& headerKey();
-  const std::string& headerValue();
+  const LowerCaseString headerKey() const;
+  const std::string headerValue() const;
 };
 
 } // namespace Http

--- a/http-filter-example/http_filter.h
+++ b/http-filter-example/http_filter.h
@@ -4,29 +4,46 @@
 
 #include "server/config/network/http_connection_manager.h"
 
+#include "http-filter-example/http_filter.pb.h"
+
 namespace Envoy {
 namespace Http {
 
+class HttpSampleDecoderFilterConfig {
+public:
+  HttpSampleDecoderFilterConfig(const sample::Decoder& proto_config);
+
+  const std::string& key() { return key_; }
+  const std::string& val() { return val_; }
+
+private:
+  std::string key_;
+  std::string val_;
+};
+
+typedef std::shared_ptr<HttpSampleDecoderFilterConfig> HttpSampleDecoderFilterConfigSharedPtr;
+
 class HttpSampleDecoderFilter : public StreamDecoderFilter {
 public:
-  HttpSampleDecoderFilter();
+  HttpSampleDecoderFilter(HttpSampleDecoderFilterConfigSharedPtr);
   ~HttpSampleDecoderFilter();
 
   // Http::StreamFilterBase
   void onDestroy() override;
 
   // Http::StreamDecoderFilter
-  FilterHeadersStatus decodeHeaders(HeaderMap& headers, bool) override;
+  FilterHeadersStatus decodeHeaders(HeaderMap&, bool) override;
   FilterDataStatus decodeData(Buffer::Instance&, bool) override;
   FilterTrailersStatus decodeTrailers(HeaderMap&) override;
-  void setDecoderFilterCallbacks(StreamDecoderFilterCallbacks& callbacks) override;
+  void setDecoderFilterCallbacks(StreamDecoderFilterCallbacks&) override;
 
 private:
+  const HttpSampleDecoderFilterConfigSharedPtr config_;
   StreamDecoderFilterCallbacks* decoder_callbacks_;
 
   const LowerCaseString& headerKey();
   const std::string& headerValue();
 };
 
-} // Http
-} // Envoy
+} // namespace Http
+} // namespace Envoy

--- a/http-filter-example/http_filter.h
+++ b/http-filter-example/http_filter.h
@@ -13,12 +13,12 @@ class HttpSampleDecoderFilterConfig {
 public:
   HttpSampleDecoderFilterConfig(const sample::Decoder& proto_config);
 
-  const std::string& key() { return key_; }
-  const std::string& val() { return val_; }
+  const std::string& key() const { return key_; }
+  const std::string& val() const { return val_; }
 
 private:
-  std::string key_;
-  std::string val_;
+  const std::string key_;
+  const std::string val_;
 };
 
 typedef std::shared_ptr<HttpSampleDecoderFilterConfig> HttpSampleDecoderFilterConfigSharedPtr;

--- a/http-filter-example/http_filter.proto
+++ b/http-filter-example/http_filter.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package sample;
+
+import "validate/validate.proto";
+
+message Decoder {
+    string key = 1 [(validate.rules).string.min_bytes = 1];
+    string val = 2 [(validate.rules).string.min_bytes = 1];
+}

--- a/http-filter-example/http_filter_config.cc
+++ b/http-filter-example/http_filter_config.cc
@@ -2,8 +2,11 @@
 
 #include "http_filter.h"
 
-#include "common/protobuf/utility.h"
+#include "common/config/json_utility.h"
 #include "envoy/registry/registry.h"
+
+#include "http-filter-example/http_filter.pb.h"
+#include "http-filter-example/http_filter.pb.validate.h"
 
 namespace Envoy {
 namespace Server {
@@ -11,31 +14,52 @@ namespace Configuration {
 
 class HttpSampleDecoderFilterConfig : public NamedHttpFilterConfigFactory {
 public:
-  HttpFilterFactoryCb createFilterFactory(const Json::Object&, const std::string&,
-                                          FactoryContext&) override {
-    return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-      callbacks.addStreamDecoderFilter(
-          Http::StreamDecoderFilterSharedPtr{new Http::HttpSampleDecoderFilter()});
-    };
+  HttpFilterFactoryCb createFilterFactory(const Json::Object& json_config, const std::string&,
+                                          FactoryContext& context) override {
+
+    sample::Decoder proto_config;
+    translateHttpSampleDecoderFilter(json_config, proto_config);
+
+    return createFilter(proto_config, context);
   }
 
-  HttpFilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message&,
+  HttpFilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& proto_config,
                                                    const std::string&,
-                                                   FactoryContext&) override {
-    return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-      callbacks.addStreamDecoderFilter(
-          Http::StreamDecoderFilterSharedPtr{new Http::HttpSampleDecoderFilter()});
-    };
+                                                   FactoryContext& context) override {
+
+    return createFilter(
+        Envoy::MessageUtil::downcastAndValidate<const sample::Decoder&>(proto_config), context);
   }
 
   /**
    *  Return the Protobuf Message that represents your config incase you have config proto
    */
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return ProtobufTypes::MessagePtr{new Envoy::ProtobufWkt::Empty()}; 
+    return ProtobufTypes::MessagePtr{new sample::Decoder()};
   }
 
   std::string name() override { return "sample"; }
+
+private:
+  HttpFilterFactoryCb createFilter(const sample::Decoder& proto_config, FactoryContext& context) {
+
+    Http::HttpSampleDecoderFilterConfigSharedPtr config =
+        std::make_shared<Http::HttpSampleDecoderFilterConfig>(
+            Http::HttpSampleDecoderFilterConfig(proto_config));
+
+    return [&context, config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+      auto filter = new Http::HttpSampleDecoderFilter(config);
+      callbacks.addStreamDecoderFilter(Http::StreamDecoderFilterSharedPtr{filter});
+    };
+  }
+
+  void translateHttpSampleDecoderFilter(const Json::Object& json_config,
+                                        sample::Decoder& proto_config) {
+
+    // normally we want to validate the json_config againts a defined json-schema here.
+    JSON_UTIL_SET_STRING(json_config, proto_config, key);
+    JSON_UTIL_SET_STRING(json_config, proto_config, val);
+  }
 };
 
 /**
@@ -44,6 +68,6 @@ public:
 static Registry::RegisterFactory<HttpSampleDecoderFilterConfig, NamedHttpFilterConfigFactory>
     register_;
 
-} // Configuration
-} // Server
-} // Envoy
+} // namespace Configuration
+} // namespace Server
+} // namespace Envoy

--- a/http-filter-example/http_filter_integration_test.cc
+++ b/http-filter-example/http_filter_integration_test.cc
@@ -1,7 +1,3 @@
-#include "common/grpc/codec.h"
-#include "common/grpc/common.h"
-#include "api/filter/network/http_connection_manager.pb.h"
-
 #include "test/integration/http_integration.h"
 #include "test/integration/utility.h"
 
@@ -9,19 +5,15 @@ namespace Envoy {
 class HttpFilterSampleIntegrationTest : public HttpIntegrationTest,
                                         public testing::TestWithParam<Network::Address::IpVersion> {
 public:
-  HttpFilterSampleIntegrationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()) {}
+  HttpFilterSampleIntegrationTest()
+      : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()) {}
   /**
    * Initializer for an individual integration test.
    */
-  void SetUp() override {
-    HttpIntegrationTest::SetUp();
-    initialize();
-  }
+  void SetUp() override { initialize(); }
 
-  void initialize() override
-  {
-    config_helper_.addFilter(
-        "{ name: sample, config: {} }");
+  void initialize() override {
+    config_helper_.addFilter("{ name: sample, config: { key: via, val: sample-filter } }");
     HttpIntegrationTest::initialize();
   }
 };
@@ -49,4 +41,4 @@ TEST_P(HttpFilterSampleIntegrationTest, Test1) {
 
   codec_client->close();
 }
-} // Envoy
+} // namespace Envoy


### PR DESCRIPTION
This patch exhibits an example of adding a .proto config to the http-filter-example. 

Closes #31.

Signed-off-by: Dhi Aurrahman <dio@hooq.tv>