### PR TITLE
Fix integration test

### DIFF
--- a/echo2_integration_test.cc
+++ b/echo2_integration_test.cc
@@ -5,10 +5,10 @@ namespace Envoy {
 class Echo2IntegrationTest : public BaseIntegrationTest,
                              public testing::TestWithParam<Network::Address::IpVersion> {
 
-std::string echoConfig() {
-  return TestEnvironment::readFileToStringForTest(TestEnvironment::runfilesPath(
-      "echo2_server.yaml"));
-}
+  std::string echoConfig() {
+    return TestEnvironment::readFileToStringForTest(
+        TestEnvironment::runfilesPath("echo2_server.yaml"));
+  }
 
 public:
   Echo2IntegrationTest() : BaseIntegrationTest(GetParam(), echoConfig()) {}
@@ -35,14 +35,15 @@ INSTANTIATE_TEST_CASE_P(IpVersions, Echo2IntegrationTest,
 TEST_P(Echo2IntegrationTest, Echo) {
   Buffer::OwnedImpl buffer("hello");
   std::string response;
-  RawConnectionDriver connection(lookupPort("echo"), buffer,
-                                 [&](Network::ClientConnection&, const Buffer::Instance& data)
-                                     -> void {
-                                       response.append(TestUtility::bufferToString(data));
-                                       connection.close();
-                                     }, GetParam());
+  RawConnectionDriver connection(
+      lookupPort("echo"), buffer,
+      [&](Network::ClientConnection&, const Buffer::Instance& data) -> void {
+        response.append(TestUtility::bufferToString(data));
+        connection.close();
+      },
+      GetParam());
 
   connection.run();
   EXPECT_EQ("hello", response);
 }
-} // Envoy
+} // namespace Envoy

--- a/echo2_integration_test.cc
+++ b/echo2_integration_test.cc
@@ -15,10 +15,7 @@ public:
   /**
    * Initializer for an individual integration test.
    */
-  void SetUp() override {
-    named_ports_ = {{"echo"}};
-    BaseIntegrationTest::initialize();
-  }
+  void SetUp() override { BaseIntegrationTest::initialize(); }
 
   /**
    * Destructor for an individual integration test.
@@ -36,7 +33,7 @@ TEST_P(Echo2IntegrationTest, Echo) {
   Buffer::OwnedImpl buffer("hello");
   std::string response;
   RawConnectionDriver connection(
-      lookupPort("echo"), buffer,
+      lookupPort("listener_0"), buffer,
       [&](Network::ClientConnection&, const Buffer::Instance& data) -> void {
         response.append(TestUtility::bufferToString(data));
         connection.close();


### PR DESCRIPTION
The integration test was broken by a recent envoy change, but it seems that CI didn't try to rebuild the filter example until I tried to update it.

This change goes along with https://github.com/envoyproxy/envoy/commit/97b69ce6a507471180c0585b6742c627962b433b