### PR TITLE
Remove dep to @envoy_api http_connection_manager

### DIFF
--- a/http-filter-example/BUILD
+++ b/http-filter-example/BUILD
@@ -51,6 +51,5 @@ envoy_cc_test(
     deps = [
         ":http_filter_config",
         "@envoy//test/integration:http_integration_lib",
-        "@envoy_api//envoy/config/filter/network/http_connection_manager/v2:http_connection_manager_cc",
     ],
 )


### PR DESCRIPTION
This patch removes `http_filter_integration_test` dep to @envoy_api's
`http_connection_manager` since the codec client type is decided inside
the `HttpIntegrationTest` class.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>