### PR TITLE
Fix echo2 test

### DIFF
--- a/echo2_config.cc
+++ b/echo2_config.cc
@@ -14,13 +14,6 @@ namespace Configuration {
  */
 class Echo2ConfigFactory : public NamedNetworkFilterConfigFactory {
 public:
-  // NamedNetworkFilterConfigFactory
-  NetworkFilterFactoryCb createFilterFactory(const Json::Object&, FactoryContext&) override {
-    return [](Network::FilterManager& filter_manager) -> void {
-      filter_manager.addReadFilter(Network::ReadFilterSharedPtr{new Filter::Echo2()});
-    };
-  }
-
   NetworkFilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message&,
                                                       FactoryContext&) override {
     return [](Network::FilterManager& filter_manager) -> void {
@@ -33,6 +26,10 @@ public:
   }
 
   std::string name() override { return "echo2"; }
+
+  NetworkFilterFactoryCb createFilterFactory(const Json::Object&, FactoryContext&) override {
+    NOT_IMPLEMENTED;
+  }
 };
 
 /**

--- a/echo2_config.cc
+++ b/echo2_config.cc
@@ -16,8 +16,20 @@ class Echo2ConfigFactory : public NamedNetworkFilterConfigFactory {
 public:
   // NamedNetworkFilterConfigFactory
   NetworkFilterFactoryCb createFilterFactory(const Json::Object&, FactoryContext&) override {
-    return [](Network::FilterManager& filter_manager)
-        -> void { filter_manager.addReadFilter(Network::ReadFilterSharedPtr{new Filter::Echo2()}); };
+    return [](Network::FilterManager& filter_manager) -> void {
+      filter_manager.addReadFilter(Network::ReadFilterSharedPtr{new Filter::Echo2()});
+    };
+  }
+
+  NetworkFilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message&,
+                                                      FactoryContext&) override {
+    return [](Network::FilterManager& filter_manager) -> void {
+      filter_manager.addReadFilter(Network::ReadFilterSharedPtr{new Filter::Echo2()});
+    };
+  }
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return ProtobufTypes::MessagePtr{new Envoy::ProtobufWkt::Empty()};
   }
 
   std::string name() override { return "echo2"; }

--- a/echo2_server.yaml
+++ b/echo2_server.yaml
@@ -19,11 +19,5 @@ static_resources:
         port_value: 0
     filter_chains:
     - filters:
-      - name: envoy.ratelimit
-        config:
-          stat_prefix: name
-          domain: foo
-          descriptors: { entries: [ { key: foo, value: bar } ] }
-
       - name: echo2
-        config: { }
+        config:

--- a/echo2_server.yaml
+++ b/echo2_server.yaml
@@ -18,12 +18,12 @@ static_resources:
         address: 127.0.0.1
         port_value: 0
     filter_chains:
-      filters:
-        name: envoy.ratelimit
+    - filters:
+      - name: envoy.ratelimit
         config:
+          stat_prefix: name
           domain: foo
-          stats_prefix: name
-          descriptors: [{"key": "foo", "value": "bar"}]
-      filters:
-        name: envoy.echo
-        config:
+          descriptors: { entries: [ { key: foo, value: bar } ] }
+
+      - name: echo2
+        config: { }


### PR DESCRIPTION
This patch fixes the `echo2` network filter integration test. By actually testing `echo2` instead of `envoy.echo` filter.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>