### PR TITLE
Fix compilation with latest Envoy master

### DIFF
--- a/http-filter-example/BUILD
+++ b/http-filter-example/BUILD
@@ -40,7 +40,7 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         ":http_filter_lib",
-        "@envoy//source/exe:envoy_common_lib",
+        "@envoy//include/envoy/server:filter_config_interface",
     ],
 )
 

--- a/http-filter-example/http_filter.cc
+++ b/http-filter-example/http_filter.cc
@@ -2,7 +2,7 @@
 
 #include "http_filter.h"
 
-#include "extensions/filters/network/http_connection_manager/config.h"
+#include "envoy/server/filter_config.h"
 
 namespace Envoy {
 namespace Http {

--- a/http-filter-example/http_filter.cc
+++ b/http-filter-example/http_filter.cc
@@ -2,7 +2,7 @@
 
 #include "http_filter.h"
 
-#include "server/config/network/http_connection_manager.h"
+#include "extensions/filters/network/http_connection_manager/config.h"
 
 namespace Envoy {
 namespace Http {

--- a/http-filter-example/http_filter.h
+++ b/http-filter-example/http_filter.h
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include "extensions/filters/network/http_connection_manager/config.h"
+#include "envoy/server/filter_config.h"
 
 #include "http-filter-example/http_filter.pb.h"
 

--- a/http-filter-example/http_filter.h
+++ b/http-filter-example/http_filter.h
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include "server/config/network/http_connection_manager.h"
+#include "extensions/filters/network/http_connection_manager/config.h"
 
 #include "http-filter-example/http_filter.pb.h"
 


### PR DESCRIPTION
This change updates the HTTP example filter to work with the latest `envoyproxy/envoy` master, which had a recent refactoring of include files.

Signed-off-by: Brian Pane <bpane@pinterest.com>