### PR TITLE
cleanup: move filter wrapper into Http namespace.

### DIFF
--- a/echo2_config.cc
+++ b/echo2_config.cc
@@ -14,8 +14,8 @@ namespace Configuration {
  */
 class Echo2ConfigFactory : public NamedNetworkFilterConfigFactory {
 public:
-  Network::NetworkFilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message&,
-                                                               FactoryContext&) override {
+  Network::FilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message&,
+                                                        FactoryContext&) override {
     return [](Network::FilterManager& filter_manager) -> void {
       filter_manager.addReadFilter(Network::ReadFilterSharedPtr{new Filter::Echo2()});
     };
@@ -27,8 +27,7 @@ public:
 
   std::string name() override { return "echo2"; }
 
-  Network::NetworkFilterFactoryCb createFilterFactory(const Json::Object&,
-                                                      FactoryContext&) override {
+  Network::FilterFactoryCb createFilterFactory(const Json::Object&, FactoryContext&) override {
     NOT_IMPLEMENTED;
   }
 };

--- a/http-filter-example/http_filter_config.cc
+++ b/http-filter-example/http_filter_config.cc
@@ -14,8 +14,8 @@ namespace Configuration {
 
 class HttpSampleDecoderFilterConfig : public NamedHttpFilterConfigFactory {
 public:
-  HttpFilterFactoryCb createFilterFactory(const Json::Object& json_config, const std::string&,
-                                          FactoryContext& context) override {
+  Http::HttpFilterFactoryCb createFilterFactory(const Json::Object& json_config, const std::string&,
+                                                FactoryContext& context) override {
 
     sample::Decoder proto_config;
     translateHttpSampleDecoderFilter(json_config, proto_config);
@@ -23,9 +23,9 @@ public:
     return createFilter(proto_config, context);
   }
 
-  HttpFilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& proto_config,
-                                                   const std::string&,
-                                                   FactoryContext& context) override {
+  Http::HttpFilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& proto_config,
+                                                         const std::string&,
+                                                         FactoryContext& context) override {
 
     return createFilter(
         Envoy::MessageUtil::downcastAndValidate<const sample::Decoder&>(proto_config), context);
@@ -41,8 +41,8 @@ public:
   std::string name() override { return "sample"; }
 
 private:
-  HttpFilterFactoryCb createFilter(const sample::Decoder& proto_config, FactoryContext& context) {
-
+  Http::HttpFilterFactoryCb createFilter(const sample::Decoder& proto_config,
+                                         FactoryContext& context) {
     Http::HttpSampleDecoderFilterConfigSharedPtr config =
         std::make_shared<Http::HttpSampleDecoderFilterConfig>(
             Http::HttpSampleDecoderFilterConfig(proto_config));

--- a/http-filter-example/http_filter_config.cc
+++ b/http-filter-example/http_filter_config.cc
@@ -14,8 +14,8 @@ namespace Configuration {
 
 class HttpSampleDecoderFilterConfig : public NamedHttpFilterConfigFactory {
 public:
-  Http::HttpFilterFactoryCb createFilterFactory(const Json::Object& json_config, const std::string&,
-                                                FactoryContext& context) override {
+  Http::FilterFactoryCb createFilterFactory(const Json::Object& json_config, const std::string&,
+                                            FactoryContext& context) override {
 
     sample::Decoder proto_config;
     translateHttpSampleDecoderFilter(json_config, proto_config);
@@ -23,9 +23,9 @@ public:
     return createFilter(proto_config, context);
   }
 
-  Http::HttpFilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& proto_config,
-                                                         const std::string&,
-                                                         FactoryContext& context) override {
+  Http::FilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& proto_config,
+                                                     const std::string&,
+                                                     FactoryContext& context) override {
 
     return createFilter(
         Envoy::MessageUtil::downcastAndValidate<const sample::Decoder&>(proto_config), context);
@@ -41,8 +41,7 @@ public:
   std::string name() override { return "sample"; }
 
 private:
-  Http::HttpFilterFactoryCb createFilter(const sample::Decoder& proto_config,
-                                         FactoryContext& context) {
+  Http::FilterFactoryCb createFilter(const sample::Decoder& proto_config, FactoryContext& context) {
     Http::HttpSampleDecoderFilterConfigSharedPtr config =
         std::make_shared<Http::HttpSampleDecoderFilterConfig>(
             Http::HttpSampleDecoderFilterConfig(proto_config));


### PR DESCRIPTION
No functional changes, missed in previous commit.