### PR TITLE
Fix compile error due to unused lambda capture

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+---
+Language:        Cpp
+AccessModifierOffset: -2
+ColumnLimit: 100
+DerivePointerAlignment: false
+PointerAlignment: Left
+SortIncludes: false
+...
+

--- a/http-filter-example/http_filter_config.cc
+++ b/http-filter-example/http_filter_config.cc
@@ -41,12 +41,12 @@ public:
   std::string name() override { return "sample"; }
 
 private:
-  Http::FilterFactoryCb createFilter(const sample::Decoder& proto_config, FactoryContext& context) {
+  Http::FilterFactoryCb createFilter(const sample::Decoder& proto_config, FactoryContext&) {
     Http::HttpSampleDecoderFilterConfigSharedPtr config =
         std::make_shared<Http::HttpSampleDecoderFilterConfig>(
             Http::HttpSampleDecoderFilterConfig(proto_config));
 
-    return [&context, config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       auto filter = new Http::HttpSampleDecoderFilter(config);
       callbacks.addStreamDecoderFilter(Http::StreamDecoderFilterSharedPtr{filter});
     };


### PR DESCRIPTION
This commit fixes the following compilation error:

```
ERROR: /Users/marpaia/git/envoy-filter-example/http-filter-example/BUILD:37:1: C++ compilation of rule '//http-filter-example:http_filter_config' failed (Exit 1)
http-filter-example/http_filter_config.cc:49:14: error: lambda capture 'context' is not used [-Werror,-Wunused-lambda-capture]
    return [&context, config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
             ^
1 error generated.
Target //http-filter-example:envoy failed to build
```

This commit also adds Envoy's `.clang-format` file so that editors don't incorrectly format C++.