### PR TITLE
bazel: add .bazelrc and use Bazel's import instead of symlinking.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+import %workspace%/envoy/.bazelrc

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,1 +1,1 @@
-../envoy/tools/bazel.rc
+import %workspace%/envoy/tools/bazel.rc

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,1 +1,0 @@
-import %workspace%/envoy/tools/bazel.rc


### PR DESCRIPTION
This is future-proofing, since %workspace%/tools/bazel.rc won't be
automatically processed starting with Bazel 0.19 (October 2018).

Signed-off-by: Piotr Sikora <piotrsikora@google.com>