### PR TITLE
Use load_assignment instead of hosts

### DIFF
--- a/echo2_server.yaml
+++ b/echo2_server.yaml
@@ -7,10 +7,15 @@ admin:
 static_resources:
   clusters:
     name: cluster_0
-    hosts:
-      socket_address:
-        address: 127.0.0.1
-        port_value: 0
+    load_assignment:
+      cluster_name: cluster_0
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: 127.0.0.1
+                    port_value: 0
   listeners:
     name: listener_0
     address:


### PR DESCRIPTION
Since [`cluster.hosts` is deprecated](https://github.com/envoyproxy/envoy/issues/4618), we use `cluster.load_assignment` to declare the workloads. 

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>