### PR TITLE
integration: make test use 3-arg base class ctor

### DIFF
--- a/echo2_integration_test.cc
+++ b/echo2_integration_test.cc
@@ -11,7 +11,7 @@ class Echo2IntegrationTest : public BaseIntegrationTest,
   }
 
 public:
-  Echo2IntegrationTest() : BaseIntegrationTest(GetParam(), echoConfig()) {}
+  Echo2IntegrationTest() : BaseIntegrationTest(GetParam(), realTime(), echoConfig()) {}
   /**
    * Initializer for an individual integration test.
    */


### PR DESCRIPTION
Make the constructor of `Echo2IntegrationTest` invoke the 3-arg version
of the `BaseIntegrationTest` constructor, in order to allow removing
the latter's overloaded constructor.

Signed-off-by: Tal Nordan <github@talnordan.com>