### PR TITLE
build: add foreign_cc rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,6 +10,10 @@ load("@envoy//bazel:cc_configure.bzl", "cc_configure")
 
 envoy_dependencies()
 
+load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
+
+rules_foreign_cc_dependencies()
+
 cc_configure()
 
 load("@envoy_api//bazel:repositories.bzl", "api_dependencies")


### PR DESCRIPTION
Builds broke as of https://github.com/envoyproxy/envoy/commit/7fa55135828dc8d93c6eee6f363534afa5cb3484

Original PR in envoy: https://github.com/envoyproxy/envoy/pull/5218

It seems like this won't be needed once the foreign_cc definitions are moved into `envoy_dependencies`?