### PR TITLE
Fix missing rules definition

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,6 +10,10 @@ load("@envoy//bazel:cc_configure.bzl", "cc_configure")
 
 envoy_dependencies()
 
+load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
+
+rules_foreign_cc_dependencies()
+
 cc_configure()
 
 load("@envoy_api//bazel:repositories.bzl", "api_dependencies")


### PR DESCRIPTION
This patch fixes a missing rules definition in WORKSPACE that caused builds to fail

Signed-off-by: Nicholas J <nicholas.a.johns5@gmail.com>

Ref: https://github.com/envoyproxy/envoy/issues/5835