### PR TITLE
test: This constructor no longer makes sense in the context of the global test-scoped singleton introduced in https://github.com/envoyproxy/envoy/pull/5708

### DIFF
--- a/echo2_integration_test.cc
+++ b/echo2_integration_test.cc
@@ -11,7 +11,7 @@ class Echo2IntegrationTest : public BaseIntegrationTest,
   }
 
 public:
-  Echo2IntegrationTest() : BaseIntegrationTest(GetParam(), realTime(), echoConfig()) {}
+  Echo2IntegrationTest() : BaseIntegrationTest(GetParam(), echoConfig()) {}
   /**
    * Initializer for an individual integration test.
    */


### PR DESCRIPTION
This constructor no longer makes sense in the context of the global test-scoped singleton introduced in [envoyproxy/envoy#5708](https://github.com/envoyproxy/envoy/pull/5708) .