### PR TITLE
Fix a build break when loading WORKSPACE file.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,7 +19,7 @@ cc_configure()
 load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
 api_dependencies()
 
-load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
 go_rules_dependencies()
 go_register_toolchains()
 load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")


### PR DESCRIPTION
It will report build failure with the latest bazel build environment. The error message is as following.
```shell
me@vm:~/envoy-filter-example$ ./ci/do_ci.sh build
clang/clang++ toolchain configured
ERROR: Failed to load Starlark extension '@io_bazel_rules_go_compat//:compat.bzl'.
It usually happens when the repository is not defined prior to being used.
Maybe repository 'io_bazel_rules_go_compat' was defined later in your WORKSPACE file?
ERROR: cycles detected during target parsing
INFO: Elapsed time: 0.178s
INFO: 0 processes.
```
A similar issue is discussed in this thread.
[https://github.com/bazelbuild/rules_go/issues/1937](https://github.com/bazelbuild/rules_go/issues/1937)