### PR TITLE
dependencies: update go_rules_dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,7 +19,7 @@ cc_configure()
 load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
 api_dependencies()
 
-load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 go_rules_dependencies()
 go_register_toolchains()
 load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")


### PR DESCRIPTION
Make `WORKSPACE` support the commit that updates to rules_go 0.17.1:
https://github.com/envoyproxy/envoy/commit/fdbbe6edaaa971f6f095a2afffbf521fe9176cee

Risk Level: Low
Testing: `bazel test //:echo2_integration_test`
Docs Changes: N/A
Release Notes: N/A

Fixes #82

Signed-off-by: Tal Nordan <github@talnordan.com>