### PR TITLE
test: Fix http integration test

### DIFF
--- a/http-filter-example/http_filter_integration_test.cc
+++ b/http-filter-example/http_filter_integration_test.cc
@@ -35,8 +35,8 @@ TEST_P(HttpFilterSampleIntegrationTest, Test1) {
   ASSERT_TRUE(request_stream->waitForEndStream(*dispatcher_));
   response->waitForEndStream();
 
-  EXPECT_STREQ("sample-filter",
-               request_stream->headers().get(Http::LowerCaseString("via"))->value().c_str());
+  EXPECT_EQ("sample-filter",
+               request_stream->headers().get(Http::LowerCaseString("via"))->value().getStringView());
 
   codec_client->close();
 }


### PR DESCRIPTION
Replace the HeaderString::c_str() API with getStringView() and EXPECT_STREQ with EXPECT_EQ for string objects comparision

Docs Changes: None
Release Notes: None
Fixes #87