### PR TITLE
Fix config file issues

### DIFF
--- a/echo2_server.json
+++ b/echo2_server.json
@@ -17,7 +17,10 @@
 
   "admin": { "access_log_path": "/dev/null",
 	     "profile_path": "{{ test_tmpdir }}/envoy.prof",
-	     "address": "tcp://{{ ip_loopback_address }}:0" },
+	     "address": {
+	       "socket_address": {"address": "127.0.0.1", "port_value": 0}
+	     }
+  },
 
   "cluster_manager": {
       "clusters": []

--- a/echo2_server.yaml
+++ b/echo2_server.yaml
@@ -7,6 +7,7 @@ admin:
 static_resources:
   clusters:
     name: cluster_0
+    connect_timeout: 0.25s
     load_assignment:
       cluster_name: cluster_0
       endpoints:


### PR DESCRIPTION
Fixes two config issues when starting envoy:

1. `echo2_server.yaml`: 
```
rchapman@x1:~/src/envoy-filter-example$ ./bazel-bin/envoy --config-path echo2_server.yaml
[2019-06-23 21:51:26.463][9476][info][main] [external/envoy/source/server/server.cc:234] initializing epoch 0 (hot restart version=11.104)
[...]
[2019-06-23 21:51:26.484][9476][critical][main] [external/envoy/source/server/server.cc:91] error initializing configuration 'echo2_server.yaml': Field 'connect_timeout' is missing in: name: "cluster_0"
[...]
```

2. `echo2_server.json`:
```
rchapman@x1:~/src/envoy-filter-example$ ./bazel-bin/envoy --config-path echo2_server.json
[2019-06-23 21:52:49.193][9542][info][main] [external/envoy/source/server/server.cc:234] initializing epoch 0 (hot restart version=11.104)
[...]
[2019-06-23 21:52:49.198][9542][critical][main] [external/envoy/source/server/server.cc:91] error initializing configuration 'echo2_server.json': Unable to parse JSON as proto (INVALID_ARGUMENT:(admin.address): invalid value "tcp://{{ ip_loopback_address }}:0" for type type.googleapis.com/envoy.api.v2.core.Address):
[...]
```
