### PR TITLE
Change INSTANTIATE_TEST_CASE_P to INSTANTIATE_TEST_SUITE_P

### DIFF
--- a/echo2_integration_test.cc
+++ b/echo2_integration_test.cc
@@ -26,7 +26,7 @@ public:
   }
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, Echo2IntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, Echo2IntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
 TEST_P(Echo2IntegrationTest, Echo) {

--- a/http-filter-example/http_filter_integration_test.cc
+++ b/http-filter-example/http_filter_integration_test.cc
@@ -17,7 +17,7 @@ public:
   }
 };
 
-INSTANTIATE_TEST_CASE_P(IpVersions, HttpFilterSampleIntegrationTest,
+INSTANTIATE_TEST_SUITE_P(IpVersions, HttpFilterSampleIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
 TEST_P(HttpFilterSampleIntegrationTest, Test1) {


### PR DESCRIPTION
As part of https://github.com/envoyproxy/envoy/pull/7426 (upgrading the current version of Googletest in use by Envoy), all uses of INSTANTIATE_TEST_CASE_P need to be changed to INSTANTIATE_TEST_SUITE_P.  This does so for the envoy-filter-example, which is used in the automatic testing of the Envoy repository.
