### PR TITLE
fix envoy-filter-example build breakage

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,16 +5,32 @@ local_repository(
     path = "envoy",
 )
 
+load("@envoy//bazel:api_binding.bzl", "envoy_api_binding")
+envoy_api_binding()
+
 load("@envoy//bazel:api_repositories.bzl", "envoy_api_dependencies")
 envoy_api_dependencies()
 
-load("@envoy//bazel:repositories.bzl", "envoy_dependencies", "GO_VERSION")
-
+load("@envoy//bazel:repositories.bzl", "envoy_dependencies")
 envoy_dependencies()
+
+load("@envoy//bazel:dependency_imports.bzl", "envoy_dependency_imports")
+envoy_dependency_imports()
 
 load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
 rules_foreign_cc_dependencies()
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies")
 go_rules_dependencies()
-go_register_toolchains(go_version = GO_VERSION)
+
+load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+
+switched_rules_by_language(
+    name = "com_google_googleapis_imports",
+    cc = True,
+    go = True,
+    grpc = True,
+    rules_override = {
+        "py_proto_library": "@envoy_api//bazel:api_build_system.bzl",
+    },
+)


### PR DESCRIPTION
the way of importing envoy dependencies is now different, this
fixes them as well as includes the changes in: #94 (which added
functionality but did not fix the build).