### PR TITLE
Add .bazelversion

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,0 +1,1 @@
+./envoy/.bazelversion


### PR DESCRIPTION
## What

- Add `.bazelversion` to enable us to use `bazelisk`.
    - It's a just symlink to submodule envoy's `.bazelversion` to use same version.

## Why

According to [Envoy's build instruction](https://github.com/envoyproxy/envoy/blob/master/bazel/README.md), we should use `bazelisk` to avoid Bazel compatibility issues.
Actually, it seems that `bazel build //:envoy` fails with latest Bazel `1.0.0`.