### PR TITLE
ignore compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bazel-*
+compile_commands.json


### PR DESCRIPTION
Just for the sake of development purpose.

In my case, I would like to use [`clangd`](https://clang.llvm.org/extra/clangd/) to read code in this repository with `compile_commands.json` generated by [bazel-compilation-database](https://github.com/grailbio/bazel-compilation-database).