### PR TITLE
update api_proto_library to api_proto_package in BUILD

### DIFF
--- a/http-filter-example/BUILD
+++ b/http-filter-example/BUILD
@@ -7,7 +7,7 @@ load(
     "envoy_cc_test",
 )
 
-load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library")
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_package")
 
 envoy_cc_binary(
     name = "envoy",
@@ -18,10 +18,7 @@ envoy_cc_binary(
     ],
 )
 
-api_proto_library(
-    name = "http_filter_proto",
-    srcs = ["http_filter.proto"]
-)
+api_proto_package()
 
 envoy_cc_library(
     name = "http_filter_lib",
@@ -29,7 +26,7 @@ envoy_cc_library(
     hdrs = ["http_filter.h"],
     repository = "@envoy",
     deps = [
-        ":http_filter_proto_cc",
+        ":pkg_cc_proto",
         "@envoy//source/exe:envoy_common_lib",
     ],
 )


### PR DESCRIPTION
Update api_proto_library to api_proto_package in BUILD file of http-filter-example to adapt new version api proto build system.

Signed-off-by: wbpcode <comems@msn.com>