### PR TITLE
api: remove v1 methods

### DIFF
--- a/echo2_config.cc
+++ b/echo2_config.cc
@@ -27,9 +27,6 @@ public:
 
   std::string name() override { return "echo2"; }
 
-  Network::FilterFactoryCb createFilterFactory(const Json::Object&, FactoryContext&) override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
   bool isTerminalFilter() override { return true; }
 };
 

--- a/http-filter-example/http_filter_config.cc
+++ b/http-filter-example/http_filter_config.cc
@@ -2,8 +2,6 @@
 
 #include "envoy/registry/registry.h"
 
-#include "common/config/json_utility.h"
-
 #include "http-filter-example/http_filter.pb.h"
 #include "http-filter-example/http_filter.pb.validate.h"
 #include "http_filter.h"
@@ -14,15 +12,6 @@ namespace Configuration {
 
 class HttpSampleDecoderFilterConfig : public NamedHttpFilterConfigFactory {
 public:
-  Http::FilterFactoryCb createFilterFactory(const Json::Object& json_config, const std::string&,
-                                            FactoryContext& context) override {
-
-    sample::Decoder proto_config;
-    translateHttpSampleDecoderFilter(json_config, proto_config);
-
-    return createFilter(proto_config, context);
-  }
-
   Http::FilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& proto_config,
                                                      const std::string&,
                                                      FactoryContext& context) override {
@@ -51,14 +40,6 @@ private:
       auto filter = new Http::HttpSampleDecoderFilter(config);
       callbacks.addStreamDecoderFilter(Http::StreamDecoderFilterSharedPtr{filter});
     };
-  }
-
-  void translateHttpSampleDecoderFilter(const Json::Object& json_config,
-                                        sample::Decoder& proto_config) {
-
-    // normally we want to validate the json_config againts a defined json-schema here.
-    JSON_UTIL_SET_STRING(json_config, proto_config, key);
-    JSON_UTIL_SET_STRING(json_config, proto_config, val);
   }
 };
 


### PR DESCRIPTION
In https://github.com/envoyproxy/envoy/pull/8749 the v1 interface methods were made optional with a default implementation because this repository still consumed those methods using `override`. Once these are cleared out, we can fully remove the v1 methods from the main codebase.

Built the change locally and verified the tests pass.

Signed-off-by: Derek Argueta <dereka@pinterest.com>