### PR TITLE
test flake: remove low timeout on test harness

### DIFF
--- a/http-filter-example/http_filter_integration_test.cc
+++ b/http-filter-example/http_filter_integration_test.cc
@@ -29,8 +29,7 @@ TEST_P(HttpFilterSampleIntegrationTest, Test1) {
 
   codec_client = makeHttpConnection(lookupPort("http"));
   auto response = codec_client->makeHeaderOnlyRequest(headers);
-  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection,
-                                                        std::chrono::milliseconds(5)));
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection));
   ASSERT_TRUE(fake_upstream_connection->waitForNewStream(*dispatcher_, request_stream));
   ASSERT_TRUE(request_stream->waitForEndStream(*dispatcher_));
   response->waitForEndStream();


### PR DESCRIPTION
Use the default upstream connection timeout for this test in
the hopes that it resolves the test flake.

Risk Level: low
Fixes: envoyproxy/envoy#9948

Signed-off-by: Stephan Zuercher <zuercher@gmail.com>
