### PR TITLE
fix a minor error in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ The [Envoy repository](https://github.com/envoyproxy/envoy/) is provided as a su
 The [`WORKSPACE`](WORKSPACE) file maps the `@envoy` repository to this local path.
 
 The [`BUILD`](BUILD) file introduces a new Envoy static binary target, `envoy`,
-that links together the new filter and `@envoy//source/exe:envoy_main_lib`. The
+that links together the new filter and `@envoy//source/exe:envoy_main_entry_lib`. The
 `echo2` filter registers itself during the static initialization phase of the
 Envoy binary as a new filter.


### PR DESCRIPTION
It should be "envoy_main_entry_lib" instead of "envoy_main_lib" based on the BUILD file. see issue https://github.com/envoyproxy/envoy-filter-example/issues/123