### PR TITLE
config: support determine terminal filter at runtime

### DIFF
--- a/echo2_config.cc
+++ b/echo2_config.cc
@@ -27,7 +27,7 @@ public:
 
   std::string name() const override { return "echo2"; }
 
-  bool isTerminalFilter() override { return true; }
+  bool isTerminalFilterByProto(const Protobuf::Message&, FactoryContext&) override { return true; }
 };
 
 /**


### PR DESCRIPTION
This pr should make https://github.com/envoyproxy/envoy/pull/15803 pass the ci which relies on this repo.