### PR TITLE
bazel: fix platform_mappings

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,2 @@
 import %workspace%/envoy/.bazelrc
+build --platform_mappings=envoy/bazel/platform_mappings


### PR DESCRIPTION
Unfortunately this setting coming from envoy's bazelrc isn't smart
enough to be WORKSPACE relative, so we have to override it with the
right path.

Fixes https://github.com/envoyproxy/envoy-filter-example/issues/155

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>