### PR TITLE
ci: Add sync workflow

### DIFF
--- a/.github/workflows/envoy-sync.yaml
+++ b/.github/workflows/envoy-sync.yaml
@@ -1,0 +1,40 @@
+name: Sync Envoy
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+    if: |
+      ${{
+          !contains(github.actor, '[bot]')
+          || github.actor == 'sync-envoy[bot]'
+      }}
+    steps:
+    - name: 'Checkout Repository'
+      uses: actions/checkout@v3
+      with:
+        ref: main
+
+    # Checkout the Envoy repo at latest commit
+    - name: 'Checkout Repository'
+      uses: actions/checkout@v3
+      with:
+        repository: envoyproxy/envoy
+        fetch-depth: 0
+        path: upstream
+
+    - run: mv upstream ../envoy
+    - run: ci/sync_envoy.sh
+      env:
+        ENVOY_SRCDIR=../envoy

--- a/ci/sync_envoy.sh
+++ b/ci/sync_envoy.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+echo "Updating Submodule..."
+# Update submodule to latest Envoy SHA
+ENVOY_SHA=$(git -C "$ENVOY_SRC_DIR" rev-parse HEAD)
+CURRENT_SHA="$(git  ls-files -s envoy | cut -d' ' -f2)"
+
+if [[ "$CURRENT_SHA" == "$ENVOY_SHA" ]]; then
+    echo "Submodule already up to date (${ENVOY_SHA})"
+    exit 0
+fi
+
+git submodule update --init
+git -C envoy checkout "$ENVOY_SHA"
+
+echo "Updating Workspace file."
+sed -e "s|{ENVOY_SRCDIR}|envoy|" "${ENVOY_SRCDIR}/ci/WORKSPACE.filter.example" > "WORKSPACE"
+
+echo "Committing, and Pushing..."
+git commit -a -m "Update Envoy submodule to $ENVOY_SHA"
+git push origin main
+echo "Done"


### PR DESCRIPTION
Currently Envoy CI uses an SSH key with all powers to sync this repo by pushing to it

This is not optimally secure, and furthermore this pattern regularly causes Envoy CI to flake racing to checkout/push downstream repos.

I have created an app with just wf trigger permissions and added it to this repo

This PR adds a workflow that can be triggered by the app to sync Envoy by pulling from it
