### PR TITLE
Parser exploration

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,7 +2,7 @@ workspace(name = "envoy_filter_example")
 
 local_repository(
     name = "envoy",
-    path = "{ENVOY_SRCDIR}",
+    path = "/home/ubuntu/envoy-filter-example/envoy",
 )
 
 load("@envoy//bazel:api_binding.bzl", "envoy_api_binding")

--- a/http-filter-example/BUILD
+++ b/http-filter-example/BUILD
@@ -1,6 +1,5 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
-    "envoy_package",
     "envoy_cc_binary",
     "envoy_cc_library",
     "envoy_cc_test",
@@ -37,7 +36,6 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         ":http_filter_lib",
-        "@envoy//envoy/registry:registry",
         "@envoy//envoy/server:filter_config_interface",
     ],
 )

--- a/http-filter-example/BUILD
+++ b/http-filter-example/BUILD
@@ -1,5 +1,6 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_package",
     "envoy_cc_binary",
     "envoy_cc_library",
     "envoy_cc_test",
@@ -36,6 +37,7 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         ":http_filter_lib",
+        "@envoy//envoy/registry:registry",
         "@envoy//envoy/server:filter_config_interface",
     ],
 )

--- a/http-filter-example/envoy-sample-config.yaml
+++ b/http-filter-example/envoy-sample-config.yaml
@@ -1,0 +1,71 @@
+admin:
+  profile_path: /tmp/envoy.prof
+  access_log:
+  - name: envoy.access_loggers.file
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+      path: /dev/null
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001
+
+
+static_resources:
+  listeners:
+  - name: web
+    address:
+      socket_address:
+        protocol: TCP
+        address: 0.0.0.0
+        port_value: 8081 # envoy entrypoint
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          codec_type: AUTO
+          stat_prefix: admin_ingress_http
+          route_config:
+            virtual_hosts:
+            - name: backend
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                  headers:
+                  - name: ":method"
+                    string_match:
+                      exact: GET
+                route:
+                  cluster: local_service
+          http_filters:
+          - name: sample
+            typed_config:
+              "@type": type.googleapis.com/sample.Decoder
+              key: via
+              val: sample-filter
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+  - name: local_service
+    connect_timeout: 30s
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    upstream_connection_options:
+      tcp_keepalive:
+        keepalive_time: 300
+    common_lb_config:
+      healthy_panic_threshold:
+        value: 40
+    load_assignment:
+      cluster_name: local_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 3000 # connected to dummy docker backend

--- a/http-filter-example/envoy-sample-config.yaml
+++ b/http-filter-example/envoy-sample-config.yaml
@@ -44,9 +44,9 @@ static_resources:
           - name: sample
             typed_config:
               "@type": type.googleapis.com/sample.Decoder
-              key: via
+              key: header-processing
               val: "set-header x-forwarded-proto https"
-              extra: "123456"
+              extra: "123456" # experiment with an additional value
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/http-filter-example/envoy-sample-config.yaml
+++ b/http-filter-example/envoy-sample-config.yaml
@@ -45,7 +45,8 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/sample.Decoder
               key: via
-              val: sample-filter
+              val: "set-header x-forwarded-proto https"
+              extra: "123456"
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/http-filter-example/http_filter.cc
+++ b/http-filter-example/http_filter.cc
@@ -35,19 +35,16 @@ int HttpSampleDecoderFilter::headerExtra() const {
 
 FilterHeadersStatus HttpSampleDecoderFilter::decodeHeaders(RequestHeaderMap& headers, bool) {
 
-  // parse config
+  // parse config: key is header operation, value is a vector of arguments for the operation
   std::unordered_map<std::string, std::vector<std::string>> header_ops;
-
   std::string header_config = headerValue();
 
   // Find the position of the first space character
   size_t spacePos = header_config.find(' ');
-
-  // Extract the key and value substrings
-  std::string key = header_config.substr(0, spacePos);
+  std::string operation = header_config.substr(0, spacePos);
   std::string args = header_config.substr(spacePos + 1);
 
-  // Create a string stream to iterate over the rest of the string
+  // Create a string stream to iterate over the arguments
   std::istringstream iss(args);
   std::vector<std::string> values;
   std::string value;
@@ -57,8 +54,8 @@ FilterHeadersStatus HttpSampleDecoderFilter::decodeHeaders(RequestHeaderMap& hea
       values.push_back(value);
   }
 
-  // Insert the key-value pair into the result map
-  header_ops[key] = values;
+  // Insert the key-value pair into header_ops
+  header_ops[operation] = values;
 
   // perform header operations
   for (auto it = header_ops.begin(); it != header_ops.end(); ++it) {
@@ -71,15 +68,6 @@ FilterHeadersStatus HttpSampleDecoderFilter::decodeHeaders(RequestHeaderMap& hea
           headers.addCopy(LowerCaseString("no"), "op"); 
         }
   }
-
-  // // add a header
-  // headers.addCopy(headerKey(), headerValue());
-  // headers.addCopy(headerKey(), headerExtra()); // adds to the same key
-  // std::string extra_header = std::to_string(headerExtra());
-  // headers.appendCopy(headerKey(), extra_header);
-  // headers.addCopy(headerKey(), headerExtra()); 
-  // headers.setCopy(headerKey(), extra_header);
-
 
   return FilterHeadersStatus::Continue;
 }

--- a/http-filter-example/http_filter.cc
+++ b/http-filter-example/http_filter.cc
@@ -1,4 +1,7 @@
 #include <string>
+#include <unordered_map>
+#include <sstream>
+#include <vector>
 
 #include "http_filter.h"
 
@@ -9,7 +12,7 @@ namespace Http {
 
 HttpSampleDecoderFilterConfig::HttpSampleDecoderFilterConfig(
     const sample::Decoder& proto_config)
-    : key_(proto_config.key()), val_(proto_config.val()) {}
+    : key_(proto_config.key()), val_(proto_config.val()), extra_(stoi(proto_config.extra())) {}
 
 HttpSampleDecoderFilter::HttpSampleDecoderFilter(HttpSampleDecoderFilterConfigSharedPtr config)
     : config_(config) {}
@@ -26,9 +29,57 @@ const std::string HttpSampleDecoderFilter::headerValue() const {
   return config_->val();
 }
 
+int HttpSampleDecoderFilter::headerExtra() const {
+  return config_->extra();
+}
+
 FilterHeadersStatus HttpSampleDecoderFilter::decodeHeaders(RequestHeaderMap& headers, bool) {
-  // add a header
-  headers.addCopy(headerKey(), headerValue());
+
+  // parse config
+  std::unordered_map<std::string, std::vector<std::string>> header_ops;
+
+  std::string header_config = headerValue();
+
+  // Find the position of the first space character
+  size_t spacePos = header_config.find(' ');
+
+  // Extract the key and value substrings
+  std::string key = header_config.substr(0, spacePos);
+  std::string args = header_config.substr(spacePos + 1);
+
+  // Create a string stream to iterate over the rest of the string
+  std::istringstream iss(args);
+  std::vector<std::string> values;
+  std::string value;
+
+  // Split the rest of the string by space and store the values in a vector
+  while (iss >> value) {
+      values.push_back(value);
+  }
+
+  // Insert the key-value pair into the result map
+  header_ops[key] = values;
+
+  // perform header operations
+  for (auto it = header_ops.begin(); it != header_ops.end(); ++it) {
+        std::string op = it->first;
+
+        if (op == "set-header") {
+          headers.setCopy(LowerCaseString(header_ops[op][0]), header_ops[op][1]);
+        }
+        else {
+          headers.addCopy(LowerCaseString("no"), "op"); 
+        }
+  }
+
+  // // add a header
+  // headers.addCopy(headerKey(), headerValue());
+  // headers.addCopy(headerKey(), headerExtra()); // adds to the same key
+  // std::string extra_header = std::to_string(headerExtra());
+  // headers.appendCopy(headerKey(), extra_header);
+  // headers.addCopy(headerKey(), headerExtra()); 
+  // headers.setCopy(headerKey(), extra_header);
+
 
   return FilterHeadersStatus::Continue;
 }

--- a/http-filter-example/http_filter.h
+++ b/http-filter-example/http_filter.h
@@ -15,10 +15,12 @@ public:
 
   const std::string& key() const { return key_; }
   const std::string& val() const { return val_; }
+  int extra() const { return extra_; }
 
 private:
   const std::string key_;
   const std::string val_;
+  const int extra_ = 0;
 };
 
 using HttpSampleDecoderFilterConfigSharedPtr = std::shared_ptr<HttpSampleDecoderFilterConfig>;
@@ -42,6 +44,7 @@ private:
 
   const LowerCaseString headerKey() const;
   const std::string headerValue() const;
+  int headerExtra() const;
 };
 
 } // namespace Http

--- a/http-filter-example/http_filter.proto
+++ b/http-filter-example/http_filter.proto
@@ -7,4 +7,5 @@ import "validate/validate.proto";
 message Decoder {
     string key = 1 [(validate.rules).string.min_bytes = 1];
     string val = 2 [(validate.rules).string.min_bytes = 1];
+    string extra = 3 [(validate.rules).string.min_bytes = 1];
 }


### PR DESCRIPTION
### Description
This PR modifies the Envoy HTTP filter plugin to perform a basic set-header operation. For example, the following config will modify the `x-forwarded-proto` header to have the value `https`.

```
- name: sample
            typed_config:
              "@type": type.googleapis.com/sample.Decoder
              key: header-processing
              val: "set-header x-forwarded-proto https"
```

### Testing
```
// Build and run envoy
bazel build //http-filter-example:envoy
./bazel-bin/http-filter-example/envoy -c ./http-filter-example/envoy-sample-config.yaml

// Set up Docker backend to echo http headers and send a curl request to envoy
// Docker image found here: https://hub.docker.com/r/ealen/echo-server
curl localhost:8081
```

We can see the specified header is set to https:
```
ubuntu@ip-10-128-172-195:~$ curl localhost:8081
{"host":{"hostname":"localhost","ip":"::ffff:172.17.0.1","ips":[]},"http":{"method":"GET","baseUrl":"","originalUrl":"/","protocol":"http"},"request":{"params":{"0":"/"},"query":{},"cookies":{},"body":{},"headers":{"host":"localhost:8081","user-agent":"curl/7.68.0","accept":"*/*","x-request-id":"9892ce28-2945-4d3e-8eb0-ab4695cf696d","x-forwarded-proto":"https","x-envoy-expected-rq-timeout-ms":"15000"}},"environment":{"PATH":"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","HOSTNAME":"e6cf43c557fd","NODE_VERSION":"16.16.0","YARN_VERSION":"1.22.19","HOME":"/root"}}
```
